### PR TITLE
Fix issue #16 HTMLParser is not defined in Node

### DIFF
--- a/src/html2json.js
+++ b/src/html2json.js
@@ -5,6 +5,10 @@
   if (typeof window === 'undefined') {
     require('../lib/Pure-JavaScript-HTML5-Parser/htmlparser.js');
   }
+  
+  if (typeof module === "object" && typeof module.exports === "object") {
+  require('../lib/Pure-JavaScript-HTML5-Parser/htmlparser.js');
+  }
 
   function q(v) {
     return '"' + v + '"';


### PR DESCRIPTION
Added condtion check to include `../lib/Pure-JavaScript-HTML5-Parser/htmlparser.js`  which does not resolve in node module .
Reference to issue #16