### PR TITLE
Allow comments under root

### DIFF
--- a/src/html2json.js
+++ b/src/html2json.js
@@ -112,7 +112,7 @@
           node: 'comment',
           text: text,
         };
-        var parent = bufArray[0];
+        var parent = bufArray[0] || results;
         if (parent.child === undefined) {
           parent.child = [];
         }

--- a/test/test.js
+++ b/test/test.js
@@ -91,6 +91,22 @@ describe('html2json', function() {
     assert.deepEqual(json, html2json(html));
     assert.deepEqual(html, json2html(json));
   });
+  
+  it('should parse top-level comment', function() {
+    var json = {
+      node: 'root',
+      child: [
+        {
+          node: 'comment',
+          text: ' foo '
+        }
+      ]
+    };
+    var html = '<!-- foo -->';
+
+    assert.deepEqual(json, html2json(html));
+    assert.deepEqual(html, json2html(json));
+  });
 
   it('should parse div with id', function() {
     var json = {


### PR DESCRIPTION
Allow comments under the root element to be parsed.

This allows parsing content like this:
```
html2json('<!-- comment -->')
```