### PR TITLE
Removal of array constructor ".last()" so that this project does not clash with other custom array methods

### DIFF
--- a/lib/Pure-JavaScript-HTML5-Parser/htmlparser.js
+++ b/lib/Pure-JavaScript-HTML5-Parser/htmlparser.js
@@ -14,43 +14,43 @@
  *
  * This code is triple licensed using Apache Software License 2.0,
  * Mozilla Public License or GNU Public License
- * 
+ *
  * ////////////////////////////////////////////////////////////////////////////
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * ////////////////////////////////////////////////////////////////////////////
- * 
+ *
  * The contents of this file are subject to the Mozilla Public License
  * Version 1.1 (the "License"); you may not use this file except in
  * compliance with the License. You may obtain a copy of the License at
  * http://www.mozilla.org/MPL/
- * 
+ *
  * Software distributed under the License is distributed on an "AS IS"
  * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
  * License for the specific language governing rights and limitations
  * under the License.
- * 
+ *
  * The Original Code is Simple HTML Parser.
- * 
+ *
  * The Initial Developer of the Original Code is Erik Arvidsson.
  * Portions created by Erik Arvidssson are Copyright (C) 2004. All Rights
  * Reserved.
- * 
+ *
  * ////////////////////////////////////////////////////////////////////////////
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -107,15 +107,11 @@
 
 	var HTMLParser = this.HTMLParser = function (html, handler) {
 		var index, chars, match, stack = [], last = html;
-		stack.last = function () {
-			return this[this.length - 1];
-		};
-
 		while (html) {
 			chars = true;
 
 			// Make sure we're not in a script or style element
-			if (!stack.last() || !special[stack.last()]) {
+			if (!stack[stack.length - 1] || !special[stack[stack.length - 1]]) {
 
 				// Comment
 				if (html.indexOf("<!--") == 0) {
@@ -160,7 +156,7 @@
 				}
 
 			} else {
-				html = html.replace(new RegExp("([\\s\\S]*?)<\/" + stack.last() + "[^>]*>"), function (all, text) {
+				html = html.replace(new RegExp("([\\s\\S]*?)<\/" + stack[stack.length - 1] + "[^>]*>"), function (all, text) {
 					text = text.replace(/<!--([\s\S]*?)-->|<!\[CDATA\[([\s\S]*?)]]>/g, "$1$2");
 					if (handler.chars)
 						handler.chars(text);
@@ -168,7 +164,7 @@
 					return "";
 				});
 
-				parseEndTag("", stack.last());
+				parseEndTag("", stack[stack.length - 1]);
 			}
 
 			if (html == last)
@@ -183,12 +179,12 @@
 			tagName = tagName.toLowerCase();
 
 			if (block[tagName]) {
-				while (stack.last() && inline[stack.last()]) {
-					parseEndTag("", stack.last());
+				while (stack[stack.length - 1] && inline[stack[stack.length - 1]]) {
+					parseEndTag("", stack[stack.length - 1]);
 				}
 			}
 
-			if (closeSelf[tagName] && stack.last() == tagName) {
+			if (closeSelf[tagName] && stack[stack.length - 1] == tagName) {
 				parseEndTag("", tagName);
 			}
 


### PR DESCRIPTION
Removal of array constructor ".last()" so that this project does not clash with other custom array methods.

Some other packages, like [`array-sugar`](https://github.com/capaj/array-sugar), add new methods for arrays.

When such packages are used with html2json, HTML parsing will fail because of the clash of the newly created array methods ".last" and ".last()".

The proposed change removes the custom array method and uses vanilla Javascript instead.

The error that will otherwise pop up is: `stack.last is not a function`.