### PR TITLE
added support to json2html for custom empty tags

### DIFF
--- a/src/html2json.js
+++ b/src/html2json.js
@@ -122,14 +122,17 @@
     return results;
   };
 
-  global.json2html = function json2html(json) {
+  global.json2html = function json2html(json, options) {
     // Empty Elements - HTML 4.01
     var empty = ['area', 'base', 'basefont', 'br', 'col', 'frame', 'hr', 'img', 'input', 'isindex', 'link', 'meta', 'param', 'embed'];
+    if(options && options.empty && Array.isArray(options.empty)) {
+      empty = empty.concat(options.empty);
+    }
 
     var child = '';
     if (json.child) {
       child = json.child.map(function(c) {
-        return json2html(c);
+        return json2html(c, options);
       }).join('');
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -35,6 +35,21 @@ describe('html2json', function() {
     assert.deepEqual(html, json2html(json));
   });
 
+  it('should parse custom empty elements', function() {
+    var json = {
+      node: 'root',
+      child: [
+        { node: 'element', tag : 'customtag' }
+      ]
+    };
+    var html = '<customtag/>';
+    var options = {
+      empty: ['customtag']
+    };
+
+    assert.deepEqual(json, html2json(html));
+    assert.deepEqual(html, json2html(json, options));
+  });
 
   it('should parse multi div', function() {
     var json = {


### PR DESCRIPTION
It adds support to `json2html` function for custom `empty` elements so we can define new elements that could be parsed back to html as single html tags. 

Full detail is described in issue https://github.com/Jxck/html2json/issues/37.